### PR TITLE
Cut down git message for embed builder crashing

### DIFF
--- a/src/utils/GitTools.ts
+++ b/src/utils/GitTools.ts
@@ -62,7 +62,7 @@ export function getGitCommitHashColor(latestCommit?: string): HexColorString {
  */
 export function getGitCommitMetadata(): GitCommitMetadata {
     try {
-        return {
+        const latestCommitMetadata = {
             author: execSync("git log -1 --pretty=%an").toString().trim(),
             color: getGitCommitHashColor(getGitCommitHash()),
             commit: getGitCommitHash(false),
@@ -72,8 +72,14 @@ export function getGitCommitMetadata(): GitCommitMetadata {
             email: execSync("git log -1 --pretty=%ae").toString().trim(),
             hash: getGitCommitHash(),
             head: execSync("git rev-parse --abbrev-ref HEAD").toString().trim(),
-            message: execSync("git log -1 --pretty=%B").toString().trim(),
+            message:
+                execSync("git log -1 --pretty=%B")
+                    .toString()
+                    .trim()
+                    .substring(0, 80) + "...",
         };
+        LogX.logD("Git commit metadata fetched:", latestCommitMetadata);
+        return latestCommitMetadata;
     } catch (error) {
         LogX.logW("Failed to get Git commit metadata:", error);
         return {


### PR DESCRIPTION
https://github.com/sharmavins23/Bombot/actions/runs/12218008291/job/34083033799

If commit message was too long, bot would crash, failing Gamma.